### PR TITLE
Fix "is" keyword improperly used to compare types

### DIFF
--- a/pieraknet/server.py
+++ b/pieraknet/server.py
@@ -39,7 +39,7 @@ class Server:
         return round(time.time() - self.start_time, 4)
 
     def send(self, data, address: tuple):
-        if not (data is bytes):
+        if not (isinstance(data, bytes)):
             data = str(data)
             data = data.encode()
         self.socket.sendto(data, address)


### PR DESCRIPTION
This is the problem we've fixed hours trying to solve - and it's all because of the pesky `is` keyword being used improperly (it can't compare types like `isinstance()` can).